### PR TITLE
Add whitelist and close TCP connections on error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+; Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace  = true
+insert_final_newline = true
+charset = utf-8
+
+; Golang
+[*.go]
+indent_style = tab
+indent_size = 4
+
+; YAML
+[*.{yaml,yml}]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,7 @@ indent_size = 4
 ; YAML
 [*.{yaml,yml}]
 indent_size = 2
+
+[Makefile]
+indent_style = tab
+indent_size = 4

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@
 build:
 	go fmt
 	go vet -v -race
-	go test -race
+	go test -v -race
 	go install .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+
+build:
+	go fmt
+	go vet -v -race
+	go test -race
+	go install .

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Sensible Proxy
+
+[![CircleCI](https://circleci.com/gh/mateusz/sensible-proxy.svg?style=svg)](https://circleci.com/gh/mateusz/sensible-proxy)
+
+

--- a/connection_proxy.go
+++ b/connection_proxy.go
@@ -5,9 +5,11 @@ import (
 	"io"
 	"log"
 	"net"
+	"sync"
 )
 
 type ConnectionProxy struct {
+	sync.Mutex
 	port      string
 	whitelist []string
 	logger    *log.Logger
@@ -26,11 +28,35 @@ func (p *ConnectionProxy) LogAccess(hostname string, conn net.Conn) bool {
 	return true
 }
 
+func (p *ConnectionProxy) Logln(v ...interface{}) {
+	p.logger.Println(v...)
+}
+
+func (p *ConnectionProxy) Logf(format string, v ...interface{}) {
+	p.logger.Printf(format, v...)
+}
+
 func (p *ConnectionProxy) Close(c io.Closer) {
 	err := c.Close()
 	if err != nil {
 		p.LogError(fmt.Sprintf("Error when closing connection: %s", err), "", nil)
 	}
+}
+
+func (p *ConnectionProxy) SetWhiteList(list []string) {
+	p.Lock()
+	p.whitelist = list
+	p.Unlock()
+}
+
+func (p *ConnectionProxy) GetWhiteList() []string {
+	var list []string
+	p.Lock()
+	for i := range p.whitelist {
+		list = append(list, p.whitelist[i])
+	}
+	p.Unlock()
+	return list
 }
 
 func (p *ConnectionProxy) IsWhiteListed(hostname string) bool {

--- a/connection_proxy.go
+++ b/connection_proxy.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+)
+
+type ConnectionProxy struct {
+	port      string
+	whitelist []string
+	logger    *log.Logger
+}
+
+func (p *ConnectionProxy) LogError(msg, hostname string, conn net.Conn) bool {
+	p.logger.Printf("%s\n", NewLogData(msg, "ERROR", hostname, conn))
+	if conn != nil {
+		p.Close(conn)
+	}
+	return false
+}
+
+func (p *ConnectionProxy) LogAccess(hostname string, conn net.Conn) bool {
+	p.logger.Printf("%s\n", NewLogData("connected", "ACCESS", hostname, conn))
+	return true
+}
+
+func (p *ConnectionProxy) Close(c io.Closer) {
+	err := c.Close()
+	if err != nil {
+		p.LogError(fmt.Sprintf("Error when closing connection: %s", err), "", nil)
+	}
+}
+
+func (p *ConnectionProxy) IsWhiteListed(hostname string) bool {
+	if len(p.whitelist) < 1 {
+		return true
+	}
+	hash := SHA1(hostname)
+	for i := range p.whitelist {
+		if string(hash) == p.whitelist[i] {
+			return true
+		}
+	}
+	return false
+}

--- a/logdata.go
+++ b/logdata.go
@@ -6,6 +6,15 @@ import (
 	"time"
 )
 
+func NewLogData(msg, msgType, hostname string, conn net.Conn) *LogData {
+	return &LogData{
+		message:     msg,
+		messageType: msgType,
+		hostname:    hostname,
+		conn:        conn,
+	}
+}
+
 type LogData struct {
 	message     string
 	messageType string
@@ -14,9 +23,9 @@ type LogData struct {
 }
 
 func (data *LogData) String() string {
-	remoteIp := "-"
+	remoteIP := "-"
 	if data.conn != nil {
-		remoteIp = data.conn.RemoteAddr().String()
+		remoteIP = data.conn.RemoteAddr().String()
 	}
 	hostname := "-"
 	message := "-"
@@ -34,7 +43,7 @@ func (data *LogData) String() string {
 	return fmt.Sprintf(
 		"%s %s %s %s %s",
 		time.Now().Format(time.RFC3339),
-		remoteIp,
+		remoteIP,
 		hostname,
 		messageType,
 		message,

--- a/sensible-proxy.go
+++ b/sensible-proxy.go
@@ -284,7 +284,7 @@ func handleHTTPSConnection(downstream net.Conn) {
 
 		current += extensionDataLength
 	}
-	if hostname == "" {
+	if hostname == "" || hostname == "127.0.0.1" {
 		logError(&LogData{message: "TLS header parsing problem - no hostname found.", conn: downstream})
 		close(downstream)
 		return

--- a/sensible-proxy.go
+++ b/sensible-proxy.go
@@ -165,13 +165,6 @@ func handleHTTPConnection(downstream net.Conn) {
 	go copyAndClose(downstream, upstream)
 }
 
-func close(c io.Closer) {
-	err := c.Close()
-	if err != nil {
-		logError(&LogData{message: fmt.Sprintf("Error when closing connection: %s", err)})
-	}
-}
-
 func handleHTTPSConnection(downstream net.Conn) {
 	firstByte := make([]byte, 1)
 	_, err := downstream.Read(firstByte)
@@ -347,6 +340,13 @@ func handleHTTPSConnection(downstream net.Conn) {
 
 	go copyAndClose(upstream, downstream)
 	go copyAndClose(downstream, upstream)
+}
+
+func close(c io.Closer) {
+	err := c.Close()
+	if err != nil {
+		logError(&LogData{message: fmt.Sprintf("Error when closing connection: %s", err)})
+	}
 }
 
 func reportError(errChan chan int) {

--- a/sensible-proxy.go
+++ b/sensible-proxy.go
@@ -293,6 +293,7 @@ func handleHTTPSConnection(downstream net.Conn) {
 	}
 	if hostname == "" {
 		logError(&LogData{message: "TLS header parsing problem - no hostname found.", conn: downstream})
+		close(downstream)
 		return
 	}
 

--- a/sensible-proxy_test.go
+++ b/sensible-proxy_test.go
@@ -43,7 +43,8 @@ func TestHTTPConnection(t *testing.T) {
 	}
 	defer conn.Close()
 
-	expected := "HTTP/1.0 302 Found"
+	// depending on the area you are testing from you might get a 301 or 302
+	expected := "HTTP/1.0 30"
 
 	if !strings.Contains(string(actual), expected) {
 		t.Errorf("Expected response to contain '%s' got:\n%s", expected, actual)
@@ -85,7 +86,9 @@ func TestHTTPSConnection(t *testing.T) {
 		return
 	}
 
-	expected := "HTTP/1.0 302 Found"
+	// depending on the area you are testing from you might get a 301 or 302
+	expected := "HTTP/1.0 30"
+
 	if !strings.Contains(string(actual), expected) {
 		t.Errorf("Expected response to contain '%s' got:\n%s", expected, actual)
 	}

--- a/sensible-proxy_test.go
+++ b/sensible-proxy_test.go
@@ -126,6 +126,21 @@ func TestHTTPSConnectionWrongSNI(t *testing.T) {
 	}
 }
 
+func TestHTTPSBadInput(t *testing.T) {
+	w := &FakeWriter{}
+	appLog = log.New(w, "", log.Ldate|log.Ltime)
+
+	var crashers = []string{
+		"\x1600\x00",
+	}
+
+	for _, crashData := range crashers {
+		b := &buffer{}
+		b.data = []byte(crashData)
+		handleHTTPSConnection(b)
+	}
+}
+
 func requestHTTP(domain string) ([]byte, net.Conn, error) {
 	done := make(chan bool)
 	defer func(doneChan chan bool) {
@@ -182,21 +197,6 @@ func getProxyServer(done chan bool, handler func(net.Conn)) (net.Listener, error
 	}(done, handler)
 
 	return listener, nil
-}
-
-func TestHTTPSBadInput(t *testing.T) {
-	w := &FakeWriter{}
-	appLog = log.New(w, "", log.Ldate|log.Ltime)
-
-	var crashers = []string{
-		"\x1600\x00",
-	}
-
-	for _, crashData := range crashers {
-		b := &buffer{}
-		b.data = []byte(crashData)
-		handleHTTPSConnection(b)
-	}
 }
 
 // buffer is just here to make it easier to inject random content into a

--- a/sensible-proxy_test.go
+++ b/sensible-proxy_test.go
@@ -36,7 +36,11 @@ func TestHTTPConnection(t *testing.T) {
 	w := &FakeWriter{}
 	appLog = log.New(w, "", log.Ldate|log.Ltime)
 
-	actual, conn, _ := requestHTTP("google.com")
+	actual, conn, err := requestHTTP("google.com")
+	if err != nil {
+		t.Errorf("%s\n", err)
+		return
+	}
 	defer conn.Close()
 
 	expected := "HTTP/1.0 302 Found"
@@ -191,7 +195,7 @@ func requestHTTPS(SNIServerName, requestServerName string) ([]byte, net.Conn, er
 }
 
 func getProxyServer(handler func(net.Conn)) (net.Listener, error) {
-	listener, err := net.Listen("tcp", ":")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, err
 	}

--- a/sensible-proxy_test.go
+++ b/sensible-proxy_test.go
@@ -95,7 +95,7 @@ func TestHTTPSConnectionEmptySNI(t *testing.T) {
 		t.Errorf("Expected connection to be closed with an EOF")
 	}
 
-	expected := "Couldn't connect to backend"
+	expected := "TLS header parsing problem - no hostname found"
 	if !strings.Contains(string(w.logs), expected) {
 		t.Errorf("Expected '%s' in logs, got %s", expected, string(w.logs))
 	}

--- a/sensible-proxy_test.go
+++ b/sensible-proxy_test.go
@@ -8,35 +8,63 @@ import (
 	"log"
 	"net"
 	"strings"
-	"testing"
 	"sync"
+	"testing"
 )
 
-type FakeWriter struct {
-	sync.Mutex
-	logs []byte
-}
-
-func (w *FakeWriter) Write(p []byte) (n int, err error) {
-	w.Lock()
-	defer w.Unlock()
-	w.logs = append(w.logs, p...)
-	return len(p), nil
-}
-
-func (w *FakeWriter) Read() []byte {
-	w.Lock()
-	defer w.Unlock()
-	temp := make([]byte, len(w.logs))
-	copy(temp, w.logs)
-	return temp
-}
-
 func TestHTTPConnection(t *testing.T) {
-	w := &FakeWriter{}
-	appLog = log.New(w, "", log.Ldate|log.Ltime)
+	w := &BufferWriter{}
 
-	actual, conn, err := requestHTTP("google.com")
+	proxy := getMockProxy(w, "google.com")
+	actual, conn, err := requestHTTP("google.com", proxy)
+	if err != nil {
+		t.Errorf("%s\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// depending on the area you are testing from you might get a 301 or 302
+	expected := "HTTP/1.0 30"
+
+	if !strings.Contains(string(actual), expected) {
+		t.Errorf("Expected response to contain '%s' got:\n%s", expected, string(actual))
+	}
+
+	logLines := w.Content()
+	expected = "google.com"
+	if !strings.Contains(string(logLines), expected) {
+		t.Errorf("Expected log to contain '%s' got:\n%s", expected, string(logLines))
+	}
+	expected = conn.LocalAddr().String()
+	if !strings.Contains(string(logLines), expected) {
+		t.Errorf("Expected log to contain '%s' got:\n%s", expected, string(logLines))
+	}
+}
+
+func TestHTTPConnectToNoneExistingDNS(t *testing.T) {
+	w := &BufferWriter{}
+	proxy := getMockProxy(w)
+	content, conn, err := requestHTTP("t.ls", proxy)
+	if err != nil {
+		t.Errorf("%s\n", err)
+		return
+	}
+	defer conn.Close()
+
+	if string(content) != "" {
+		t.Errorf("Expected read to be empty")
+	}
+	logLines := w.Content()
+	expected := "Couldn't connect to backend"
+	if !strings.Contains(string(logLines), expected) {
+		t.Errorf("Expected '%s' in logs, got %s", expected, string(logLines))
+	}
+}
+
+func TestHTTPSConnection(t *testing.T) {
+	w := &BufferWriter{}
+	proxy := getMockProxy(w, "google.com")
+	actual, conn, err := requestHTTPS("google.com", "google.com", proxy)
 	if err != nil {
 		t.Errorf("%s\n", err)
 		return
@@ -50,50 +78,7 @@ func TestHTTPConnection(t *testing.T) {
 		t.Errorf("Expected response to contain '%s' got:\n%s", expected, actual)
 	}
 
-	logLines := w.Read()
-	expected = "google.com"
-	if !strings.Contains(string(logLines), expected) {
-		t.Errorf("Expected log to contain '%s' got:\n%s", expected, w.logs)
-	}
-	expected = conn.LocalAddr().String()
-	if !strings.Contains(string(logLines), expected) {
-		t.Errorf("Expected log to contain '%s' got:\n%s", expected, w.logs)
-	}
-}
-
-func TestHTTPConnectToNoneExistingDNS(t *testing.T) {
-	w := &FakeWriter{}
-	appLog = log.New(w, "", log.Ldate|log.Ltime)
-	content, conn, _ := requestHTTP("t.ls")
-	defer conn.Close()
-	if string(content) != "" {
-		t.Errorf("Expected read to be empty")
-	}
-	logLines := w.Read()
-	expected := "Couldn't connect to backend"
-	if !strings.Contains(string(logLines), expected) {
-		t.Errorf("Expected '%s' in logs, got %s", expected, string(logLines))
-	}
-}
-
-func TestHTTPSConnection(t *testing.T) {
-	w := &FakeWriter{}
-	appLog = log.New(w, "", log.Ldate|log.Ltime)
-	actual, conn, err := requestHTTPS("google.com", "google.com")
-	defer conn.Close()
-	if err != nil {
-		t.Errorf("Error on read: %s", err)
-		return
-	}
-
-	// depending on the area you are testing from you might get a 301 or 302
-	expected := "HTTP/1.0 30"
-
-	if !strings.Contains(string(actual), expected) {
-		t.Errorf("Expected response to contain '%s' got:\n%s", expected, actual)
-	}
-
-	logLines := w.Read()
+	logLines := w.Content()
 	expected = "google.com"
 	if !strings.Contains(string(logLines), expected) {
 		t.Errorf("Expected log to contain '%s' got:\n%s", expected, string(logLines))
@@ -105,10 +90,10 @@ func TestHTTPSConnection(t *testing.T) {
 }
 
 func TestHTTPSConnectionEmptySNI(t *testing.T) {
-	w := &FakeWriter{}
-	appLog = log.New(w, "", log.Ldate|log.Ltime)
-	_, conn, err := requestHTTPS("", "google.com")
+	w := &BufferWriter{}
+	proxy := getMockProxy(w, "google.com")
 
+	_, conn, err := requestHTTPS("", "google.com", proxy)
 	if conn != nil {
 		t.Errorf("Expected connection to be nil")
 		conn.Close()
@@ -117,7 +102,7 @@ func TestHTTPSConnectionEmptySNI(t *testing.T) {
 	if err != io.EOF {
 		t.Errorf("Expected connection to be closed with an EOF")
 	}
-	logLines := w.Read()
+	logLines := w.Content()
 	expected := "TLS header parsing problem - no hostname found"
 	if !strings.Contains(string(logLines), expected) {
 		t.Errorf("Expected '%s' in logs, got %s", expected, string(logLines))
@@ -125,21 +110,21 @@ func TestHTTPSConnectionEmptySNI(t *testing.T) {
 }
 
 func TestHTTPSConnectionWrongSNI(t *testing.T) {
-	w := &FakeWriter{}
-	appLog = log.New(w, "", log.Ldate|log.Ltime)
-	actual, conn, err := requestHTTPS("example.com", "google.com")
-	defer conn.Close()
+	w := &BufferWriter{}
+	proxy := getMockProxy(w, "example.com", "google.com")
+	actual, conn, err := requestHTTPS("example.com", "google.com", proxy)
 	if err != nil {
-		t.Errorf("%s", err)
+		t.Errorf("%s\n", err)
 		return
 	}
+	defer conn.Close()
 
 	expected := "HTTP/1.0 404 Not Found"
 	if !strings.Contains(string(actual), expected) {
 		t.Errorf("Expected response to contain '%s' got:\n%s", expected, actual)
 	}
 
-	logLines := w.Read()
+	logLines := w.Content()
 	expected = "example.com"
 	if !strings.Contains(string(logLines), expected) {
 		t.Errorf("Expected log to contain '%s' got:\n%s", expected, string(logLines))
@@ -150,9 +135,40 @@ func TestHTTPSConnectionWrongSNI(t *testing.T) {
 	}
 }
 
+func TestHTTPWhitelistBlocks(t *testing.T) {
+	w := &BufferWriter{}
+	proxy := getMockProxy(w, "somedomain.com", "someother.com")
+	_, conn, err := requestHTTP("google.com", proxy)
+	if err == nil {
+		defer conn.Close()
+	}
+	defer conn.Close()
+
+	logLines := w.Content()
+	expected := "google.com ERROR: Hostname is not whitelisted"
+	if !strings.Contains(string(logLines), expected) {
+		t.Errorf("Expected log to contain '%s' got:\n%s", expected, string(logLines))
+	}
+}
+
+func TestHTTPSWhitelistBlocks(t *testing.T) {
+	w := &BufferWriter{}
+	proxy := getMockProxy(w, "somedomain.com", "someother.com")
+	_, conn, err := requestHTTPS("google.com", "google.com", proxy)
+	if err == nil {
+		defer conn.Close()
+	}
+
+	logLines := w.Content()
+	expected := "google.com ERROR: Hostname is not whitelisted"
+	if !strings.Contains(string(logLines), expected) {
+		t.Errorf("Expected log to contain '%s' got:\n%s", expected, string(logLines))
+	}
+}
+
 func TestHTTPSBadInput(t *testing.T) {
-	w := &FakeWriter{}
-	appLog = log.New(w, "", log.Ldate|log.Ltime)
+	w := &BufferWriter{}
+	proxy := getMockProxy(w)
 
 	var crashers = []string{
 		"\x1600\x00",
@@ -161,12 +177,12 @@ func TestHTTPSBadInput(t *testing.T) {
 	for _, crashData := range crashers {
 		b := &buffer{}
 		b.data = []byte(crashData)
-		handleHTTPSConnection(b)
+		handleHTTPSConnection(b, proxy)
 	}
 }
 
-func requestHTTP(domain string) ([]byte, net.Conn, error) {
-	listener, err := getProxyServer(handleHTTPConnection)
+func requestHTTP(domain string, proxy *ConnectionProxy) ([]byte, net.Conn, error) {
+	listener, err := getProxyServer(handleHTTPConnection, proxy)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -181,8 +197,8 @@ func requestHTTP(domain string) ([]byte, net.Conn, error) {
 	return content, conn, err
 }
 
-func requestHTTPS(SNIServerName, requestServerName string) ([]byte, net.Conn, error) {
-	listener, err := getProxyServer(handleHTTPSConnection)
+func requestHTTPS(SNIServerName, requestServerName string, proxy *ConnectionProxy) ([]byte, net.Conn, error) {
+	listener, err := getProxyServer(handleHTTPSConnection, proxy)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -197,20 +213,30 @@ func requestHTTPS(SNIServerName, requestServerName string) ([]byte, net.Conn, er
 	return content, conn, err
 }
 
-func getProxyServer(handler func(net.Conn)) (net.Listener, error) {
+func getProxyServer(handler tcpHandler, proxy *ConnectionProxy) (net.Listener, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return nil, err
+		return listener, err
 	}
-	go func(handler func(net.Conn)) {
+	go func(handler tcpHandler, proxy *ConnectionProxy) {
 		connection, err := listener.Accept()
 		if err != nil {
 			panic(err)
 		}
-		handler(connection)
-	}(handler)
-
+		handler(connection, proxy)
+	}(handler, proxy)
 	return listener, nil
+}
+
+func getMockProxy(mockLogger io.Writer, whiteListedDomains ...string) *ConnectionProxy {
+	var whiteList []string
+	for _, domain := range whiteListedDomains {
+		whiteList = append(whiteList, SHA1(domain))
+	}
+	return &ConnectionProxy{
+		logger:    log.New(mockLogger, "", log.Ldate|log.Ltime),
+		whitelist: whiteList,
+	}
 }
 
 // buffer is just here to make it easier to inject random content into a
@@ -227,4 +253,25 @@ func (b *buffer) Read(p []byte) (n int, err error) {
 
 func (b *buffer) Close() error {
 	return nil
+}
+
+type BufferWriter struct {
+	sync.Mutex
+	logs []byte
+	asd  io.ReadWriteCloser
+}
+
+func (w *BufferWriter) Write(p []byte) (n int, err error) {
+	w.Lock()
+	defer w.Unlock()
+	w.logs = append(w.logs, p...)
+	return len(p), nil
+}
+
+func (w *BufferWriter) Content() []byte {
+	w.Lock()
+	defer w.Unlock()
+	temp := make([]byte, len(w.logs))
+	copy(temp, w.logs)
+	return temp
 }


### PR DESCRIPTION
Introduces a new ENV variable `WHITELIST_URL` that should contain a list of domains one per line. Each domain must be hashed as 40 char long SHA1. If there are any connection problems or the list is empty, all domains are allowed.

fixes problem where the client connection hangs until the TCP times out even if we know that we cannot connect to a host because of missing hostname in the SNI.

There are also a couple of cases where we detected errors on the connection, but did not close the connection, which unfortunately will cause a lot of open TCP connections that will not be harvested until the linux kernel feels like it.
