### PR TITLE
Keep previous whitelist on fetch failure

### DIFF
--- a/sensible-proxy.go
+++ b/sensible-proxy.go
@@ -110,7 +110,7 @@ func periodicWhiteListUpdate(proxy, tlsProxy *ConnectionProxy, url string) {
 		if len(whiteList) > 0 {
 			proxy.Logf("Fetched %d white listed domains\n", len(whiteList))
 		} else {
-			proxy.Logln("Could not find whitelist, allowing all domains\n")
+			proxy.Logln("Could not find whitelist, allowing all domains")
 		}
 		proxy.SetWhiteList(whiteList)
 		tlsProxy.SetWhiteList(whiteList)


### PR DESCRIPTION
Due to how much illegitimate traffic the proxy can get, we should not open up the proxy when fetching fails, keep the state.

This happens for example if the domains list is getting deployed or intermittent internet failure.